### PR TITLE
ci: add monthly wiki refresh reminder issue workflow

### DIFF
--- a/.github/workflows/wiki-refresh-reminder.yml
+++ b/.github/workflows/wiki-refresh-reminder.yml
@@ -22,15 +22,27 @@ jobs:
             const month = String(now.getUTCMonth() + 1).padStart(2, '0');
             const period = `${year}-${month}`;
             const title = `Wiki refresh - ${period}`;
+            const wikiBase = `https://github.com/${context.repo.owner}/${context.repo.repo}/wiki`;
 
-            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`;
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue in:title "${title}"`;
             const result = await github.rest.search.issuesAndPullRequests({
               q: query,
               per_page: 1,
             });
 
             if (result.data.total_count > 0) {
-              core.info(`Open issue already exists for ${period}. Skipping.`);
+              const existing = result.data.items[0];
+              if (existing.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  state: 'open',
+                });
+                core.info(`Reopened existing issue #${existing.number} for ${period}.`);
+                return;
+              }
+              core.info(`Issue #${existing.number} already exists for ${period}. Skipping.`);
               return;
             }
 
@@ -48,9 +60,9 @@ jobs:
               '- Ensure no personal phone numbers are exposed in public wiki pages.',
               '',
               'Reference pages:',
-              '- https://github.com/UmeshCode1/ai-ml-club/wiki/Wiki-Update-Protocol',
-              '- https://github.com/UmeshCode1/ai-ml-club/wiki/Social-Handles-and-Official-Channels',
-              '- https://github.com/UmeshCode1/ai-ml-club/wiki/Event-Timeline-and-Archive',
+              `- ${wikiBase}/Wiki-Update-Protocol`,
+              `- ${wikiBase}/Social-Handles-and-Official-Channels`,
+              `- ${wikiBase}/Event-Timeline-and-Archive`,
             ].join('\n');
 
             await github.rest.issues.create({

--- a/.github/workflows/wiki-refresh-reminder.yml
+++ b/.github/workflows/wiki-refresh-reminder.yml
@@ -1,0 +1,63 @@
+name: Wiki Refresh Reminder
+
+on:
+  schedule:
+    - cron: "0 6 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  open-wiki-refresh-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create monthly wiki refresh issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const now = new Date();
+            const year = now.getUTCFullYear();
+            const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+            const period = `${year}-${month}`;
+            const title = `Wiki refresh - ${period}`;
+
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`;
+            const result = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 1,
+            });
+
+            if (result.data.total_count > 0) {
+              core.info(`Open issue already exists for ${period}. Skipping.`);
+              return;
+            }
+
+            const body = [
+              '## Monthly Wiki Refresh Checklist',
+              '',
+              `Period: ${period}`,
+              '',
+              'Keep the club wiki current by reviewing and updating the following:',
+              '',
+              '- Validate social and communication links.',
+              '- Update event timeline entries for newly completed events.',
+              '- Verify roster/role changes are reflected in wiki pages.',
+              '- Confirm Home and sidebar navigation links are still valid.',
+              '- Ensure no personal phone numbers are exposed in public wiki pages.',
+              '',
+              'Reference pages:',
+              '- https://github.com/UmeshCode1/ai-ml-club/wiki/Wiki-Update-Protocol',
+              '- https://github.com/UmeshCode1/ai-ml-club/wiki/Social-Handles-and-Official-Channels',
+              '- https://github.com/UmeshCode1/ai-ml-club/wiki/Event-Timeline-and-Archive',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+
+            core.info(`Created wiki refresh issue: ${title}`);


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Actions workflow that opens a monthly wiki refresh issue
- include duplicate protection so only one issue is opened per month
- include a practical checklist with links to wiki maintenance pages

## Why
Main branch protection requires PR-based changes. This automation helps keep wiki content continuously updated.

## Workflow details
- file: `.github/workflows/wiki-refresh-reminder.yml`
- triggers: `schedule` (1st day of month at 06:00 UTC) and `workflow_dispatch`
- permissions: `issues: write`, `contents: read`
